### PR TITLE
Fix shell script issues

### DIFF
--- a/helpers/gentoken.sh
+++ b/helpers/gentoken.sh
@@ -12,8 +12,8 @@ function main() {
         exit 0
     fi
 
-    token=$( cat $environment | grep "bearier_token" | awk -F'=' '{print $2}' )
-    if [ -n $token ]; then
+    token=$(grep "bearier_token" "$environment" | awk -F'=' '{print $2}')
+    if [ -n "$token" ]; then
         read -p "Bearier Token yet exist, want to create a new one (Y/n)?" select
         if [ "$select" == "Y" ]; then
             echo -n "Generate new token... "

--- a/helpers/stressapi.sh
+++ b/helpers/stressapi.sh
@@ -4,9 +4,11 @@ TSDB_URL="http://localhost:8086/api/v2/write?orgID=2d72070bfb91b366&bucket=stres
 TSDB_TOKEN="Authorization: Token TfqpqTgS0s3o-E4pZhN9kzN2liJH4EysdoQvJshuRbqBXH9qRg39rXPlSU0pCNNhsiNDsACxgk52aKF3SpNsbg=="
 
 containers=($(docker ps --filter "ancestor=alpine/curl-http3:latest" --format "{{.Names}}"))
+i=0
 
 while sleep 1; do
-    while [ $i -lt ${#containers[@]} ]; do
+    i=0
+    while [ "$i" -lt "${#containers[@]}" ]; do
         (
             CONTAINER=${containers[$i]}
             START=$(($(date +%s) * 1000 + $(date +%-N) / 1000000))


### PR DESCRIPTION
## Summary
- update gentoken.sh quoting
- fix iteration logic in stressapi script

## Testing
- `bash -n helpers/gentoken.sh`
- `bash -n helpers/stressapi.sh`
- `python -m py_compile application/app/main.py application/app/database.py application/app/models.py application/app/routers/*.py`
- `find webcurl -name '*.py' | tr '\n' ' ' | xargs python -m py_compile`

------
https://chatgpt.com/codex/tasks/task_e_685c66f42d38832e89ff81aeb304c296