### PR TITLE
Add user registration page and API

### DIFF
--- a/application/app/main.py
+++ b/application/app/main.py
@@ -3,7 +3,7 @@ from fastapi.responses import JSONResponse
 from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
 from fastapi_limiter import FastAPILimiter
 from fastapi_limiter.depends import RateLimiter
-from app.routers import quizzes, healthcheck
+from app.routers import quizzes, healthcheck, users
 from app.database import connect_to_mongo
 
 import os
@@ -64,4 +64,11 @@ app.include_router(
     prefix="/quizzes",
     dependencies=[Depends(authenticate)],
     tags=["quizzes"]
+)
+
+# Rota para gerenciamento de usuários
+app.include_router(
+    users.router,
+    prefix="/users",
+    tags=["users"]
 )

--- a/application/app/models.py
+++ b/application/app/models.py
@@ -45,3 +45,17 @@ class QuizOutput(BaseModel):
     id: str
     name: str
     questions: List[QuestionOutput] = []
+
+class UserInput(BaseModel):
+    """Modelo para entrada de dados de um usuário."""
+    email: str
+    first_name: str
+    last_name: str
+    password: str
+
+class UserOutput(BaseModel):
+    """Modelo para saída de dados de um usuário."""
+    id: str
+    email: str
+    first_name: str
+    last_name: str

--- a/application/app/routers/users.py
+++ b/application/app/routers/users.py
@@ -1,0 +1,31 @@
+from fastapi import APIRouter, HTTPException, Request
+from app.models import UserInput, UserOutput
+
+router = APIRouter()
+
+@router.post("/", response_model=UserOutput)
+async def create_user(request: Request, user: UserInput):
+    db = request.app.state.db
+    if db is None:
+        raise HTTPException(status_code=500, detail="Erro na conexão com o banco de dados")
+
+    existing = await db["users"].find_one({"email": user.email})
+    if existing:
+        raise HTTPException(status_code=400, detail="E-mail já cadastrado")
+
+    document = {
+        "email": user.email,
+        "first_name": user.first_name,
+        "last_name": user.last_name,
+        "password": user.password
+    }
+
+    result = await db["users"].insert_one(document)
+    created = await db["users"].find_one({"_id": result.inserted_id})
+
+    return UserOutput(
+        id=str(created["_id"]),
+        email=created["email"],
+        first_name=created["first_name"],
+        last_name=created["last_name"]
+    )

--- a/frontend-home/app/index.html
+++ b/frontend-home/app/index.html
@@ -22,7 +22,7 @@
                 <div class="form-check form-switch">
                     <input class="form-check-input custom-switch" type="checkbox" id="theme-toggler">
                 </div>
-                <a class="btn btn-outline-primary rounded-pill" href="#" id="openRegisterModal" data-translate="register">%register%</a>
+                <a class="btn btn-outline-primary rounded-pill" href="/register/" data-translate="register">%register%</a>
                 <a class="btn btn-outline-primary rounded-pill" href="#" data-translate="login">%login%</a>
             </div>
         </div>
@@ -35,30 +35,8 @@
         </div>
     </main>
 
-    <!-- Espaço para carregar o modal -->
-    <div id="modalContainer"></div>
-
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
     <script src="scripts/theme-toggle.js"></script>
     <script src="scripts/language.js"></script>
-    <script>
-        // Carregar modal dinamicamente
-        document.getElementById('openRegisterModal').addEventListener('click', async (e) => {
-            e.preventDefault();
-            const modalContainer = document.getElementById('modalContainer');
-            try {
-                const response = await fetch('register-modal.html');
-                const modalContent = await response.text();
-                modalContainer.innerHTML = modalContent;
-                
-                // Recarregar o script do modal
-                const script = document.createElement('script');
-                script.src = 'scripts/register-modal.js';
-                document.body.appendChild(script);
-            } catch (error) {
-                console.error('Erro ao carregar o modal:', error);
-            }
-        });
-    </script>
 </body>
 </html>

--- a/frontend-home/app/register/index.html
+++ b/frontend-home/app/register/index.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Create User</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body class="p-3">
+    <h1 class="mb-4">Create User</h1>
+    <form id="userForm" class="needs-validation" novalidate>
+        <div class="mb-3">
+            <label for="email" class="form-label">Email</label>
+            <input type="email" class="form-control" id="email" required>
+            <div class="invalid-feedback">Please provide a valid email.</div>
+        </div>
+        <div class="mb-3">
+            <label for="firstName" class="form-label">First Name</label>
+            <input type="text" class="form-control" id="firstName" required>
+        </div>
+        <div class="mb-3">
+            <label for="lastName" class="form-label">Last Name</label>
+            <input type="text" class="form-control" id="lastName" required>
+        </div>
+        <div class="mb-3">
+            <label for="password" class="form-label">Password</label>
+            <input type="password" class="form-control" id="password" required>
+        </div>
+        <button type="submit" class="btn btn-primary">Create</button>
+        <a href="/" class="btn btn-secondary ms-2">Back</a>
+    </form>
+    <script>
+        const form = document.getElementById('userForm');
+        form.addEventListener('submit', async (e) => {
+            e.preventDefault();
+            const data = {
+                email: document.getElementById('email').value,
+                first_name: document.getElementById('firstName').value,
+                last_name: document.getElementById('lastName').value,
+                password: document.getElementById('password').value
+            };
+            try {
+                const res = await fetch('https://localhost:4433/users/', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify(data)
+                });
+                if (res.ok) {
+                    alert('Usuário criado com sucesso!');
+                    window.location.href = '/';
+                } else {
+                    const json = await res.json();
+                    alert(json.detail || 'Erro ao criar usuário');
+                }
+            } catch (err) {
+                alert('Erro de conexão');
+            }
+        });
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- include new user models
- create `/users` API endpoint to register a new user and check for duplicate emails
- expose the user router in the FastAPI app
- link to friendly `/register/` URL from the home page
- add registration form at `/register/index.html`

## Testing
- `python -m py_compile application/app/main.py application/app/models.py application/app/routers/*.py`


------
https://chatgpt.com/codex/tasks/task_e_685dbfc06278832e83b8616fb595bb30