### PR TITLE
Optimize webcurl scripts

### DIFF
--- a/webcurl/application/database.py
+++ b/webcurl/application/database.py
@@ -9,7 +9,8 @@ def load_config(config_path="config.yml"):
 config = load_config()
 
 # Obtenha o caminho do DB a partir de uma variável de ambiente, ou use um padrão gravável
-db_path = os.getenv("TINYDB_PATH", "/tmp/db.json")
+default_db = os.path.join(os.path.dirname(__file__), "..", "data", "db", "db.json")
+db_path = os.getenv("TINYDB_PATH", default_db)
 
 db = TinyDB(db_path)
 queries_table = db.table("queries")

--- a/webcurl/application/static/scripts/service-worker.js
+++ b/webcurl/application/static/scripts/service-worker.js
@@ -1,7 +1,6 @@
 const CACHE_NAME = "webcurl-cache-v1";
 const urlsToCache = [
     "/", // Página principal
-    "/template/index.html",
     "/static/styles/base.css",
     "/static/styles/sidebar.css",
     "/static/styles/editor.css",


### PR DESCRIPTION
## Summary
- make TinyDB path relative to repository
- harden curl execution by avoiding shell
- fix service worker path

## Testing
- `python3 -m py_compile webcurl/application/routes/execute.py webcurl/application/database.py`

------
https://chatgpt.com/codex/tasks/task_e_68706848c164832ea68d1a2d04d473cf